### PR TITLE
【开源实习】技术公开课内容测试任务3

### DIFF
--- a/Season1.step_into_chatgpt/3.GPT/gpt_imdb_finetune.ipynb
+++ b/Season1.step_into_chatgpt/3.GPT/gpt_imdb_finetune.ipynb
@@ -10,40 +10,38 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\n",
-      "Collecting mindspore==2.4.1\n",
-      "  Using cached https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.1/MindSpore/unified/aarch64/mindspore-2.4.1-cp39-cp39-linux_aarch64.whl (335.5 MB)\n",
-      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.26.4)\n",
-      "Requirement already satisfied: protobuf>=3.13.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (6.30.2)\n",
-      "Requirement already satisfied: asttokens>=2.0.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (3.0.0)\n",
-      "Requirement already satisfied: pillow>=6.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (11.2.1)\n",
-      "Requirement already satisfied: scipy>=1.5.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.13.1)\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (24.2)\n",
-      "Requirement already satisfied: psutil>=5.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (5.9.0)\n",
-      "Requirement already satisfied: astunparse>=1.6.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.6.3)\n",
-      "Requirement already satisfied: safetensors>=0.4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (0.5.3)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.1) (0.45.1)\n",
-      "Requirement already satisfied: six<2.0,>=1.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.1) (1.17.0)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
+      "Collecting mindspore==2.5.0\n",
+      "  Downloading https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.5.0/MindSpore/unified/aarch64/mindspore-2.5.0-cp39-cp39-linux_aarch64.whl (345.0 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m345.0/345.0 MB\u001b[0m \u001b[31m112.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: pip in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (25.0.1)\n",
+      "\u001b[31mERROR: Could not find a version that satisfies the requirement install (from versions: none)\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n",
+      "\u001b[31mERROR: No matching distribution found for install\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
      ]
     }
    ],
    "source": [
-    "!pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.1/MindSpore/unified/aarch64/mindspore-2.4.1-cp39-cp39-linux_aarch64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple"
+    "!pip install pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.5.0/MindSpore/unified/aarch64/mindspore-2.5.0-cp39-cp39-linux_aarch64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -65,52 +63,52 @@
       "Requirement already satisfied: pyctcdecode in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.5.0)\n",
       "Requirement already satisfied: jieba in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.42.1)\n",
       "Requirement already satisfied: pytest==7.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (7.2.0)\n",
-      "Requirement already satisfied: pillow>=10.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (11.2.1)\n",
+      "Requirement already satisfied: pillow>=10.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (11.1.0)\n",
       "Requirement already satisfied: attrs>=19.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (25.3.0)\n",
       "Requirement already satisfied: iniconfig in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (2.1.0)\n",
       "Requirement already satisfied: packaging in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (24.2)\n",
       "Requirement already satisfied: pluggy<2.0,>=0.12 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (1.5.0)\n",
       "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (1.2.0)\n",
       "Requirement already satisfied: tomli>=1.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (2.2.1)\n",
-      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from tokenizers==0.19.1->mindnlp==0.4.0) (0.31.1)\n",
-      "Requirement already satisfied: filelock in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (3.18.0)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (2025.3.0)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (6.0.2)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (4.12.2)\n",
-      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (1.1.0)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from tokenizers==0.19.1->mindnlp==0.4.0) (0.32.3)\n",
       "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.26.4)\n",
       "Requirement already satisfied: protobuf>=3.13.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (6.30.2)\n",
-      "Requirement already satisfied: asttokens>=2.0.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (3.0.0)\n",
+      "Requirement already satisfied: asttokens>=2.0.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (2.0.5)\n",
       "Requirement already satisfied: scipy>=1.5.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.13.1)\n",
       "Requirement already satisfied: psutil>=5.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (5.9.0)\n",
       "Requirement already satisfied: astunparse>=1.6.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.6.3)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.0) (0.45.1)\n",
-      "Requirement already satisfied: six<2.0,>=1.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.0) (1.17.0)\n",
+      "Requirement already satisfied: filelock in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (3.18.0)\n",
       "Requirement already satisfied: pyarrow>=15.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (20.0.0)\n",
       "Requirement already satisfied: dill<0.3.9,>=0.3.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (0.3.8)\n",
       "Requirement already satisfied: pandas in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (2.2.3)\n",
       "Requirement already satisfied: xxhash in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (3.5.0)\n",
       "Requirement already satisfied: multiprocess<0.70.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (0.70.16)\n",
-      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (3.11.18)\n",
-      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (2.6.1)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.3.2)\n",
-      "Requirement already satisfied: async-timeout<6.0,>=4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (5.0.1)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.6.0)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (6.4.3)\n",
-      "Requirement already satisfied: propcache>=0.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (0.3.1)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.20.0)\n",
-      "Requirement already satisfied: idna>=2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from yarl<2.0,>=1.17.0->aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (3.10)\n",
+      "Requirement already satisfied: fsspec<=2025.3.0,>=2023.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (2025.3.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (6.0.2)\n",
       "Requirement already satisfied: charset-normalizer<4,>=2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (3.4.1)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2.4.0)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2025.4.26)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2.3.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2025.1.31)\n",
+      "Requirement already satisfied: pygtrie<3.0,>=2.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (2.5.0)\n",
+      "Requirement already satisfied: hypothesis<7,>=6.14 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (6.133.2)\n",
+      "Requirement already satisfied: six in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from asttokens>=2.0.4->mindspore>=2.2.14->mindnlp==0.4.0) (1.16.0)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.0) (0.45.1)\n",
+      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (3.12.7)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (4.12.2)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (1.1.2)\n",
+      "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from hypothesis<7,>=6.14->pyctcdecode->mindnlp==0.4.0) (2.4.0)\n",
       "Requirement already satisfied: python-dateutil>=2.8.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2.9.0.post0)\n",
       "Requirement already satisfied: pytz>=2020.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2025.2)\n",
       "Requirement already satisfied: tzdata>=2022.7 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2025.2)\n",
-      "Requirement already satisfied: pygtrie<3.0,>=2.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (2.5.0)\n",
-      "Requirement already satisfied: hypothesis<7,>=6.14 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (6.131.15)\n",
-      "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from hypothesis<7,>=6.14->pyctcdecode->mindnlp==0.4.0) (2.4.0)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.3.2)\n",
+      "Requirement already satisfied: async-timeout<6.0,>=4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (5.0.1)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.6.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (6.4.4)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (0.3.1)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.20.0)\n",
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
      ]
     }
@@ -122,7 +120,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -131,7 +131,7 @@
       "Looking in indexes: https://repo.huaweicloud.com/repository/pypi/simple/\n",
       "Requirement already satisfied: jieba in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (0.42.1)\n",
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
      ]
     }
@@ -143,7 +143,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -168,13 +170,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.338 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleGetModelId failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleGetModelId\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.397 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleLoadFromMem failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleLoadFromMem\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.422 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleUnload failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleUnload\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.560 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtGetMemUceInfo failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtGetMemUceInfo\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.585 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtDeviceTaskAbort failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtDeviceTaskAbort\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.608 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtMemUceRepair failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtMemUceRepair\n",
-      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.220.620 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol acltdtCleanChannel failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libacl_tdt_channel.so: undefined symbol: acltdtCleanChannel\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:02.546.745 [mindspore/run_check/_check_version.py:329] MindSpore version 2.4.1 and Ascend AI software package (Ascend Data Center Solution)version 7.6 does not match, the version of software package expect one of ['7.3', '7.5']. Please refer to the match info on: https://www.mindspore.cn/install\n",
       "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
       "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
@@ -183,9 +179,26 @@
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
       "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:04.810.368 [mindspore/run_check/_check_version.py:347] MindSpore version 2.4.1 and \"te\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:04.812.087 [mindspore/run_check/_check_version.py:354] MindSpore version 2.4.1 and \"hccl\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:04.812.731 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 3\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:05.814.363 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 2\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:06.816.061 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 1\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:09.473.235 [mindspore/run_check/_check_version.py:329] MindSpore version 2.4.1 and Ascend AI software package (Ascend Data Center Solution)version 7.6 does not match, the version of software package expect one of ['7.3', '7.5']. Please refer to the match info on: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:09.474.964 [mindspore/run_check/_check_version.py:347] MindSpore version 2.4.1 and \"te\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:09.475.567 [mindspore/run_check/_check_version.py:354] MindSpore version 2.4.1 and \"hccl\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:09.476.234 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 3\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:10.477.850 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 2\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:11.478.869 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 1\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:12.480.761 [mindspore/run_check/_check_version.py:329] MindSpore version 2.4.1 and Ascend AI software package (Ascend Data Center Solution)version 7.6 does not match, the version of software package expect one of ['7.3', '7.5']. Please refer to the match info on: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:12.482.175 [mindspore/run_check/_check_version.py:347] MindSpore version 2.4.1 and \"te\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:12.482.802 [mindspore/run_check/_check_version.py:354] MindSpore version 2.4.1 and \"hccl\" wheel package version 7.6 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:12.483.400 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 3\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:13.485.045 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 2\n",
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:14.486.640 [mindspore/run_check/_check_version.py:368] Please pay attention to the above warning, countdown: 1\n",
       "Building prefix dict from the default dictionary ...\n",
       "Loading model from cache /tmp/jieba.cache\n",
-      "Loading model cost 1.054 seconds.\n",
+      "Loading model cost 1.075 seconds.\n",
       "Prefix dict has been built successfully.\n"
      ]
     }
@@ -244,7 +257,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -277,7 +292,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -306,13 +323,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] ME(767:281472868163616,MainProcess):2025-05-13-09:57:01.419.139 [mindspore/dataset/engine/datasets.py:2534] Dataset is shuffled before split.\n"
+      "[WARNING] ME(250:281472944873504,MainProcess):2025-06-03-14:44:51.758.363 [mindspore/dataset/engine/datasets.py:2534] Dataset is shuffled before split.\n"
      ]
     }
    ],
@@ -324,7 +343,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "dataset_train = process_dataset(imdb_train, gpt_tokenizer, shuffle=True)\n",
@@ -335,22 +356,24 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[Tensor(shape=[4, 512], dtype=Int64, value=\n",
-       " [[  871,  1456,  4265 ... 40480, 40480, 40480],\n",
-       "  [  249,  1085,  1291 ... 40480, 40480, 40480],\n",
-       "  [  557,   509,   485 ...  5253,   239,   557],\n",
-       "  [  715,   481,  1218 ... 40480, 40480, 40480]]),\n",
+       " [[  500,   246,  1322 ... 40480, 40480, 40480],\n",
+       "  [ 1473,   980,   246 ... 40480, 40480, 40480],\n",
+       "  [39516,   498,   481 ... 40480, 40480, 40480],\n",
+       "  [  616,   544,   808 ... 40480, 40480, 40480]]),\n",
        " Tensor(shape=[4, 512], dtype=Int64, value=\n",
        " [[1, 1, 1 ... 0, 0, 0],\n",
        "  [1, 1, 1 ... 0, 0, 0],\n",
-       "  [1, 1, 1 ... 1, 1, 1],\n",
+       "  [1, 1, 1 ... 0, 0, 0],\n",
        "  [1, 1, 1 ... 0, 0, 0]]),\n",
-       " Tensor(shape=[4], dtype=Int32, value= [1, 0, 0, 0])]"
+       " Tensor(shape=[4], dtype=Int32, value= [1, 1, 0, 0])]"
       ]
      },
      "execution_count": 12,
@@ -365,7 +388,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import evaluate\n",
@@ -383,12 +408,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc8679bdfd1b4cbcb87b709b2da90fa3",
+       "model_id": "94d1b9d8276a4040a27030d34c8d44e2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -398,35 +425,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Failed to download: HTTPSConnectionPool(host='cas-bridge.xethub.hf-mirror.com', port=443): Read timed out.\n",
-      "Retrying... (attempt 0/5)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d19a99c922824691b0e50326c80dbc08",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       " 56%|#####6    | 256M/457M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[WARNING] DEVICE(767,ffff82522020,python):2025-05-13-10:03:12.555.795 [mindspore/ccsrc/plugin/device/ascend/hal/device/ascend_memory_adapter.cc:116] Initialize] Free memory size is less than half of total memory size.Device 0 Device HBM total size:34359738368 Device HBM free size:7523115008 may be other processes occupying this card, check as: ps -ef|grep python\n"
-     ]
     },
     {
      "name": "stdout",
@@ -478,12 +476,14 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d174f78ebf843a9834aa6180d1c2520",
+       "model_id": "a14e623641474a878a018804439a22f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -498,9 +498,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.5402, 'learning_rate': 1.69558599695586e-05, 'epoch': 0.46}\n",
-      "{'loss': 0.4599, 'learning_rate': 1.39117199391172e-05, 'epoch': 0.91}\n",
-      "/\r"
+      "......{'loss': 0.5623, 'learning_rate': 1.69558599695586e-05, 'epoch': 0.46}\n",
+      ".{'loss': 0.5065, 'learning_rate': 1.39117199391172e-05, 'epoch': 0.91}\n",
+      "."
      ]
     },
     {
@@ -521,9 +521,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.40077418088912964, 'eval_accuracy': 0.8986666666666666, 'eval_runtime': 13.9761, 'eval_samples_per_second': 13.452, 'eval_steps_per_second': 13.452, 'epoch': 1.0}\n",
-      "{'loss': 0.3289, 'learning_rate': 1.08675799086758e-05, 'epoch': 1.37}\n",
-      "{'loss': 0.188, 'learning_rate': 7.823439878234399e-06, 'epoch': 1.83}\n"
+      "{'eval_loss': 0.38103795051574707, 'eval_accuracy': 0.8893333333333333, 'eval_runtime': 12.8526, 'eval_samples_per_second': 14.627, 'eval_steps_per_second': 14.627, 'epoch': 1.0}\n",
+      "{'loss': 0.3234, 'learning_rate': 1.08675799086758e-05, 'epoch': 1.37}\n",
+      "{'loss': 0.1771, 'learning_rate': 7.823439878234399e-06, 'epoch': 1.83}\n"
      ]
     },
     {
@@ -544,9 +544,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.6022735834121704, 'eval_accuracy': 0.8906666666666667, 'eval_runtime': 13.8122, 'eval_samples_per_second': 13.611, 'eval_steps_per_second': 13.611, 'epoch': 2.0}\n",
-      "{'loss': 0.1476, 'learning_rate': 4.779299847792998e-06, 'epoch': 2.28}\n",
-      "{'loss': 0.0777, 'learning_rate': 1.7351598173515982e-06, 'epoch': 2.74}\n"
+      "{'eval_loss': 0.5746207237243652, 'eval_accuracy': 0.892, 'eval_runtime': 12.5869, 'eval_samples_per_second': 14.936, 'eval_steps_per_second': 14.936, 'epoch': 2.0}\n",
+      "{'loss': 0.1717, 'learning_rate': 4.779299847792998e-06, 'epoch': 2.28}\n",
+      "{'loss': 0.0905, 'learning_rate': 1.7351598173515982e-06, 'epoch': 2.74}\n"
      ]
     },
     {
@@ -567,14 +567,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.572710394859314, 'eval_accuracy': 0.9026666666666666, 'eval_runtime': 13.7343, 'eval_samples_per_second': 13.688, 'eval_steps_per_second': 13.688, 'epoch': 3.0}\n",
-      "{'train_runtime': 585.155, 'train_samples_per_second': 8.982, 'train_steps_per_second': 2.246, 'train_loss': 0.27094667650974685, 'epoch': 3.0}\n"
+      "{'eval_loss': 0.5379959344863892, 'eval_accuracy': 0.9013333333333333, 'eval_runtime': 12.6645, 'eval_samples_per_second': 14.845, 'eval_steps_per_second': 14.845, 'epoch': 3.0}\n",
+      "{'train_runtime': 544.4598, 'train_samples_per_second': 9.654, 'train_steps_per_second': 2.413, 'train_loss': 0.28584540307612544, 'epoch': 3.0}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TrainOutput(global_step=1314, training_loss=0.27094667650974685, metrics={'train_runtime': 585.155, 'train_samples_per_second': 8.982, 'train_steps_per_second': 2.246, 'train_loss': 0.27094667650974685, 'epoch': 3.0})"
+       "TrainOutput(global_step=1314, training_loss=0.28584540307612544, metrics={'train_runtime': 544.4598, 'train_samples_per_second': 9.654, 'train_steps_per_second': 2.413, 'train_loss': 0.28584540307612544, 'epoch': 3.0})"
       ]
      },
      "execution_count": 15,
@@ -626,13 +626,15 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/188 [00:15<?, ?it/s]"
+      "  0%|          | 0/188 [00:14<?, ?it/s]"
      ]
     },
     {

--- a/Season1.step_into_chatgpt/3.GPT/gpt_imdb_finetune.ipynb
+++ b/Season1.step_into_chatgpt/3.GPT/gpt_imdb_finetune.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -18,28 +18,21 @@
      "text": [
       "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\n",
       "Collecting mindspore==2.4.1\n",
-      "  Downloading https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.1/MindSpore/unified/aarch64/mindspore-2.4.1-cp39-cp39-linux_aarch64.whl (335.5 MB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m335.5/335.5 MB\u001b[0m \u001b[31m6.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (1.26.1)\n",
-      "Requirement already satisfied: protobuf>=3.13.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (3.20.3)\n",
-      "Requirement already satisfied: asttokens>=2.0.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (2.4.1)\n",
-      "Requirement already satisfied: pillow>=6.2.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (9.0.1)\n",
-      "Requirement already satisfied: scipy>=1.5.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (1.11.3)\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (23.2)\n",
-      "Requirement already satisfied: psutil>=5.6.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (5.9.5)\n",
-      "Requirement already satisfied: astunparse>=1.6.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.1) (1.6.3)\n",
-      "Collecting safetensors>=0.4.0 (from mindspore==2.4.1)\n",
-      "  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/08/94/7760694760f1e5001bd62c93155b8b7ccb652d1f4d0161d1e72b5bf9581a/safetensors-0.4.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (442 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m442.4/442.4 kB\u001b[0m \u001b[31m8.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: six>=1.12.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from asttokens>=2.0.4->mindspore==2.4.1) (1.16.0)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.1) (0.41.2)\n",
-      "\u001b[33mDEPRECATION: moxing-framework 2.1.16.2ae09d45 has a non-standard version number. pip 24.0 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of moxing-framework or contact the author to suggest that they release a version with a conforming version number. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
-      "\u001b[0mInstalling collected packages: safetensors, mindspore\n",
-      "  Attempting uninstall: mindspore\n",
-      "    Found existing installation: mindspore 2.3.0\n",
-      "    Uninstalling mindspore-2.3.0:\n",
-      "      Successfully uninstalled mindspore-2.3.0\n",
-      "Successfully installed mindspore-2.4.1 safetensors-0.4.5\n"
+      "  Using cached https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.1/MindSpore/unified/aarch64/mindspore-2.4.1-cp39-cp39-linux_aarch64.whl (335.5 MB)\n",
+      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.26.4)\n",
+      "Requirement already satisfied: protobuf>=3.13.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (6.30.2)\n",
+      "Requirement already satisfied: asttokens>=2.0.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (3.0.0)\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (11.2.1)\n",
+      "Requirement already satisfied: scipy>=1.5.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.13.1)\n",
+      "Requirement already satisfied: packaging>=20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (24.2)\n",
+      "Requirement already satisfied: psutil>=5.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (5.9.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (1.6.3)\n",
+      "Requirement already satisfied: safetensors>=0.4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore==2.4.1) (0.5.3)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.1) (0.45.1)\n",
+      "Requirement already satisfied: six<2.0,>=1.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.1) (1.17.0)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
      ]
     }
    ],
@@ -49,26 +42,97 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install mindnlp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Looking in indexes: http://pip.modelarts.private.com:8888/repository/pypi/simple\n",
-      "Requirement already satisfied: jieba in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (0.42.1)\n",
-      "\u001b[33mWARNING: You are using pip version 21.0.1; however, version 24.3.1 is available.\n",
-      "You should consider upgrading via the '/home/ma-user/anaconda3/envs/MindSpore/bin/python3.9 -m pip install --upgrade pip' command.\u001b[0m\n"
+      "Looking in indexes: https://repo.huaweicloud.com/repository/pypi/simple/\n",
+      "Requirement already satisfied: mindnlp==0.4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (0.4.0)\n",
+      "Requirement already satisfied: mindspore>=2.2.14 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (2.4.1)\n",
+      "Requirement already satisfied: tqdm in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (4.67.1)\n",
+      "Requirement already satisfied: requests in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (2.32.3)\n",
+      "Requirement already satisfied: datasets in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (3.6.0)\n",
+      "Requirement already satisfied: evaluate in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.4.3)\n",
+      "Requirement already satisfied: tokenizers==0.19.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.19.1)\n",
+      "Requirement already satisfied: safetensors in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.5.3)\n",
+      "Requirement already satisfied: sentencepiece in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.2.0)\n",
+      "Requirement already satisfied: regex in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (2024.11.6)\n",
+      "Requirement already satisfied: addict in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (2.4.0)\n",
+      "Requirement already satisfied: ml-dtypes in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.5.1)\n",
+      "Requirement already satisfied: pyctcdecode in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.5.0)\n",
+      "Requirement already satisfied: jieba in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (0.42.1)\n",
+      "Requirement already satisfied: pytest==7.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (7.2.0)\n",
+      "Requirement already satisfied: pillow>=10.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindnlp==0.4.0) (11.2.1)\n",
+      "Requirement already satisfied: attrs>=19.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (25.3.0)\n",
+      "Requirement already satisfied: iniconfig in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (2.1.0)\n",
+      "Requirement already satisfied: packaging in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (24.2)\n",
+      "Requirement already satisfied: pluggy<2.0,>=0.12 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (1.5.0)\n",
+      "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (1.2.0)\n",
+      "Requirement already satisfied: tomli>=1.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.0) (2.2.1)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from tokenizers==0.19.1->mindnlp==0.4.0) (0.31.1)\n",
+      "Requirement already satisfied: filelock in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (3.18.0)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (2025.3.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (6.0.2)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (4.12.2)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.0) (1.1.0)\n",
+      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.26.4)\n",
+      "Requirement already satisfied: protobuf>=3.13.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (6.30.2)\n",
+      "Requirement already satisfied: asttokens>=2.0.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (3.0.0)\n",
+      "Requirement already satisfied: scipy>=1.5.4 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.13.1)\n",
+      "Requirement already satisfied: psutil>=5.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (5.9.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.3 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.0) (1.6.3)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.0) (0.45.1)\n",
+      "Requirement already satisfied: six<2.0,>=1.6.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.0) (1.17.0)\n",
+      "Requirement already satisfied: pyarrow>=15.0.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (20.0.0)\n",
+      "Requirement already satisfied: dill<0.3.9,>=0.3.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (0.3.8)\n",
+      "Requirement already satisfied: pandas in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (2.2.3)\n",
+      "Requirement already satisfied: xxhash in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (3.5.0)\n",
+      "Requirement already satisfied: multiprocess<0.70.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from datasets->mindnlp==0.4.0) (0.70.16)\n",
+      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (3.11.18)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.3.2)\n",
+      "Requirement already satisfied: async-timeout<6.0,>=4.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (5.0.1)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.6.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (6.4.3)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (0.3.1)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (1.20.0)\n",
+      "Requirement already satisfied: idna>=2.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from yarl<2.0,>=1.17.0->aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.0) (3.10)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (3.4.1)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2.4.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->mindnlp==0.4.0) (2025.4.26)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2.9.0.post0)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2025.2)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.0) (2025.2)\n",
+      "Requirement already satisfied: pygtrie<3.0,>=2.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (2.5.0)\n",
+      "Requirement already satisfied: hypothesis<7,>=6.14 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.0) (6.131.15)\n",
+      "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from hypothesis<7,>=6.14->pyctcdecode->mindnlp==0.4.0) (2.4.0)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install mindnlp==0.4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://repo.huaweicloud.com/repository/pypi/simple/\n",
+      "Requirement already satisfied: jieba in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (0.42.1)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n"
      ]
     }
    ],
@@ -78,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -95,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -104,33 +168,24 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.558 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleGetModelId failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleGetModelId\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.609 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleLoadFromMem failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleLoadFromMem\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.629 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleUnload failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleUnload\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.823 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtGetMemUceInfo failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtGetMemUceInfo\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.839 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtDeviceTaskAbort failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtDeviceTaskAbort\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.751.855 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtMemUceRepair failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtMemUceRepair\n",
-      "[WARNING] GE_ADPT(44827,ffff813130b0,python):2025-01-05-01:02:28.753.785 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol acltdtCleanChannel failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libacl_tdt_channel.so: undefined symbol: acltdtCleanChannel\n",
-      "[WARNING] ME(44827:281472849227952,MainProcess):2025-01-05-01:02:28.877.761 [mindspore/run_check/_check_version.py:398] Can not find the tbe operator implementation(need by mindspore-ascend). Please check whether the Environment Variable PYTHONPATH is set. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.338 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleGetModelId failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleGetModelId\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.397 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleLoadFromMem failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleLoadFromMem\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.422 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleUnload failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleUnload\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.560 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtGetMemUceInfo failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtGetMemUceInfo\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.585 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtDeviceTaskAbort failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtDeviceTaskAbort\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.218.608 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtMemUceRepair failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtMemUceRepair\n",
+      "[WARNING] GE_ADPT(767,ffff82522020,python):2025-05-13-09:56:11.220.620 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol acltdtCleanChannel failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libacl_tdt_channel.so: undefined symbol: acltdtCleanChannel\n",
+      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n",
-      "[WARNING] ME(44827:281472849227952,MainProcess):2025-01-05-01:02:39.387.242 [mindspore/run_check/_check_version.py:398] Can not find the tbe operator implementation(need by mindspore-ascend). Please check whether the Environment Variable PYTHONPATH is set. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "[WARNING] ME(44827:281472849227952,MainProcess):2025-01-05-01:02:39.390.836 [mindspore/run_check/_check_version.py:398] Can not find the tbe operator implementation(need by mindspore-ascend). Please check whether the Environment Variable PYTHONPATH is set. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "cannot found `mindformers.experimental`, please install dev version by\n",
-      "`pip install git+https://gitee.com/mindspore/mindformers` \n",
-      "or remove mindformers by \n",
-      "`pip uninstall mindformers`\n",
       "Building prefix dict from the default dictionary ...\n",
       "Loading model from cache /tmp/jieba.cache\n",
-      "Loading model cost 1.298 seconds.\n",
+      "Loading model cost 1.054 seconds.\n",
       "Prefix dict has been built successfully.\n"
      ]
     }
@@ -150,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -166,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "tags": []
    },
@@ -177,7 +232,7 @@
        "2500"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -229,7 +284,7 @@
      "output_type": "stream",
      "text": [
       "ftfy or spacy is not installed using BERT BasicTokenizer instead of SpaCy & ftfy.\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/mindnlp/transformers/tokenization_utils_base.py:1526: FutureWarning: `clean_up_tokenization_spaces` was not set. It will be set to `True` by default. This behavior will be depracted, and will be then set to `False` by default. \n",
+      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/mindnlp/transformers/tokenization_utils_base.py:1526: FutureWarning: `clean_up_tokenization_spaces` was not set. It will be set to `True` by default. This behavior will be depracted, and will be then set to `False` by default. \n",
       "  warnings.warn(\n"
      ]
     }
@@ -250,14 +305,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] ME(44827:281472849227952,MainProcess):2025-01-05-01:03:04.229.025 [mindspore/dataset/engine/datasets.py:2534] Dataset is shuffled before split.\n"
+      "[WARNING] ME(767:281472868163616,MainProcess):2025-05-13-09:57:01.419.139 [mindspore/dataset/engine/datasets.py:2534] Dataset is shuffled before split.\n"
      ]
     }
    ],
@@ -268,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,26 +334,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[Tensor(shape=[4, 512], dtype=Int64, value=\n",
-       " [[  595,   881,   566 ... 40480, 40480, 40480],\n",
-       "  [  246, 18351, 15369 ... 40480, 40480, 40480],\n",
-       "  [  616,  4121,  4020 ... 40480, 40480, 40480],\n",
-       "  [  249,  4336,   616 ... 40480, 40480, 40480]]),\n",
+       " [[  871,  1456,  4265 ... 40480, 40480, 40480],\n",
+       "  [  249,  1085,  1291 ... 40480, 40480, 40480],\n",
+       "  [  557,   509,   485 ...  5253,   239,   557],\n",
+       "  [  715,   481,  1218 ... 40480, 40480, 40480]]),\n",
        " Tensor(shape=[4, 512], dtype=Int64, value=\n",
        " [[1, 1, 1 ... 0, 0, 0],\n",
        "  [1, 1, 1 ... 0, 0, 0],\n",
-       "  [1, 1, 1 ... 0, 0, 0],\n",
+       "  [1, 1, 1 ... 1, 1, 1],\n",
        "  [1, 1, 1 ... 0, 0, 0]]),\n",
-       " Tensor(shape=[4], dtype=Int32, value= [1, 1, 1, 1])]"
+       " Tensor(shape=[4], dtype=Int32, value= [1, 0, 0, 0])]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,14 +382,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fc8679bdfd1b4cbcb87b709b2da90fa3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0.00/457M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Failed to download: HTTPSConnectionPool(host='cas-bridge.xethub.hf-mirror.com', port=443): Read timed out.\n",
+      "Retrying... (attempt 0/5)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d19a99c922824691b0e50326c80dbc08",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       " 56%|#####6    | 256M/457M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] DEVICE(44827,ffff813130b0,python):2025-01-05-01:03:07.513.644 [mindspore/ccsrc/plugin/device/ascend/hal/device/ascend_vmm_adapter.h:188] CheckVmmDriverVersion] Driver version is less than 24.0.0, vmm is disabled by default, drvier_version: 23.0.6\n",
+      "[WARNING] DEVICE(767,ffff82522020,python):2025-05-13-10:03:12.555.795 [mindspore/ccsrc/plugin/device/ascend/hal/device/ascend_memory_adapter.cc:116] Initialize] Free memory size is less than half of total memory size.Device 0 Device HBM total size:34359738368 Device HBM free size:7523115008 may be other processes occupying this card, check as: ps -ef|grep python\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[MS_ALLOC_CONF]Runtime config:  enable_vmm:True  vmm_align_size:2MB\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "Some weights of OpenAIGPTForSequenceClassification were not initialized from the model checkpoint at openai-gpt and are newly initialized: ['score.weight']\n",
       "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
      ]
@@ -373,406 +477,107 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 15%|█▌        | 200/1314 [01:09<04:34,  4.05it/s]"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d174f78ebf843a9834aa6180d1c2520",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1314 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.5636, 'learning_rate': 1.69558599695586e-05, 'epoch': 0.46}\n"
+      "{'loss': 0.5402, 'learning_rate': 1.69558599695586e-05, 'epoch': 0.46}\n",
+      "{'loss': 0.4599, 'learning_rate': 1.39117199391172e-05, 'epoch': 0.91}\n",
+      "/\r"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 15%|█▌        | 201/1314 [01:09<05:49,  3.19it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-\r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 31%|███       | 401/1314 [01:56<03:14,  4.69it/s]"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/188 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.4809, 'learning_rate': 1.39117199391172e-05, 'epoch': 0.91}\n"
+      "{'eval_loss': 0.40077418088912964, 'eval_accuracy': 0.8986666666666666, 'eval_runtime': 13.9761, 'eval_samples_per_second': 13.452, 'eval_steps_per_second': 13.452, 'epoch': 1.0}\n",
+      "{'loss': 0.3289, 'learning_rate': 1.08675799086758e-05, 'epoch': 1.37}\n",
+      "{'loss': 0.188, 'learning_rate': 7.823439878234399e-06, 'epoch': 1.83}\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 33%|███▎      | 438/1314 [02:04<03:12,  4.54it/s]\n",
-      "  0%|          | 0/188 [00:00<?, ?it/s]\u001b[A"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\\\r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  1%|          | 2/188 [00:00<01:19,  2.35it/s]\u001b[A\n",
-      "  2%|▏         | 3/188 [00:01<01:40,  1.85it/s]\u001b[A\n",
-      "  2%|▏         | 4/188 [00:02<01:52,  1.63it/s]\u001b[A\n",
-      "  3%|▎         | 5/188 [00:03<02:04,  1.48it/s]\u001b[A\n",
-      "  3%|▎         | 6/188 [00:04<02:18,  1.31it/s]\u001b[A\n",
-      "  4%|▎         | 7/188 [00:04<02:03,  1.47it/s]\u001b[A\n",
-      "  5%|▍         | 9/188 [00:04<01:09,  2.59it/s]\u001b[A\n",
-      "  6%|▌         | 11/188 [00:04<00:44,  3.93it/s]\u001b[A\n",
-      "  6%|▋         | 12/188 [00:04<00:39,  4.44it/s]\u001b[A\n",
-      "  7%|▋         | 14/188 [00:05<00:28,  6.01it/s]\u001b[A\n",
-      "  9%|▊         | 16/188 [00:05<00:23,  7.46it/s]\u001b[A\n",
-      " 10%|▉         | 18/188 [00:05<00:19,  8.83it/s]\u001b[A\n",
-      " 11%|█         | 20/188 [00:05<00:16, 10.27it/s]\u001b[A\n",
-      " 12%|█▏        | 22/188 [00:05<00:14, 11.30it/s]\u001b[A\n",
-      " 13%|█▎        | 24/188 [00:05<00:12, 12.65it/s]\u001b[A\n",
-      " 14%|█▍        | 26/188 [00:05<00:12, 12.91it/s]\u001b[A\n",
-      " 15%|█▍        | 28/188 [00:06<00:12, 13.22it/s]\u001b[A\n",
-      " 16%|█▌        | 30/188 [00:06<00:11, 13.46it/s]\u001b[A\n",
-      " 17%|█▋        | 32/188 [00:06<00:10, 14.42it/s]\u001b[A\n",
-      " 18%|█▊        | 34/188 [00:06<00:11, 13.82it/s]\u001b[A\n",
-      " 19%|█▉        | 36/188 [00:06<00:11, 13.12it/s]\u001b[A\n",
-      " 20%|██        | 38/188 [00:06<00:11, 13.40it/s]\u001b[A\n",
-      " 21%|██▏       | 40/188 [00:06<00:10, 14.12it/s]\u001b[A\n",
-      " 22%|██▏       | 42/188 [00:07<00:10, 13.45it/s]\u001b[A\n",
-      " 23%|██▎       | 44/188 [00:07<00:10, 13.60it/s]\u001b[A\n",
-      " 24%|██▍       | 46/188 [00:07<00:10, 13.61it/s]\u001b[A\n",
-      " 26%|██▌       | 48/188 [00:07<00:09, 14.04it/s]\u001b[A\n",
-      " 27%|██▋       | 50/188 [00:07<00:09, 14.50it/s]\u001b[A\n",
-      " 28%|██▊       | 52/188 [00:07<00:09, 15.07it/s]\u001b[A\n",
-      " 29%|██▊       | 54/188 [00:07<00:08, 15.92it/s]\u001b[A\n",
-      " 30%|██▉       | 56/188 [00:07<00:08, 16.03it/s]\u001b[A\n",
-      " 31%|███       | 58/188 [00:08<00:08, 15.44it/s]\u001b[A\n",
-      " 32%|███▏      | 60/188 [00:08<00:08, 15.38it/s]\u001b[A\n",
-      " 33%|███▎      | 62/188 [00:08<00:08, 15.63it/s]\u001b[A\n",
-      " 34%|███▍      | 64/188 [00:08<00:07, 15.97it/s]\u001b[A\n",
-      " 35%|███▌      | 66/188 [00:08<00:08, 15.06it/s]\u001b[A\n",
-      " 36%|███▌      | 68/188 [00:08<00:08, 14.52it/s]\u001b[A\n",
-      " 38%|███▊      | 72/188 [00:08<00:05, 19.40it/s]\u001b[A\n",
-      " 40%|████      | 76/188 [00:08<00:04, 23.94it/s]\u001b[A\n",
-      " 43%|████▎     | 80/188 [00:09<00:03, 27.49it/s]\u001b[A\n",
-      " 45%|████▍     | 84/188 [00:09<00:03, 30.01it/s]\u001b[A\n",
-      " 47%|████▋     | 88/188 [00:09<00:03, 31.97it/s]\u001b[A\n",
-      " 49%|████▉     | 92/188 [00:09<00:02, 33.20it/s]\u001b[A\n",
-      " 51%|█████     | 96/188 [00:09<00:02, 34.13it/s]\u001b[A\n",
-      " 53%|█████▎    | 100/188 [00:09<00:02, 34.42it/s]\u001b[A\n",
-      " 55%|█████▌    | 104/188 [00:09<00:02, 34.77it/s]\u001b[A\n",
-      " 57%|█████▋    | 108/188 [00:09<00:02, 34.96it/s]\u001b[A\n",
-      " 60%|█████▉    | 112/188 [00:09<00:02, 35.20it/s]\u001b[A\n",
-      " 62%|██████▏   | 116/188 [00:10<00:02, 35.28it/s]\u001b[A\n",
-      " 64%|██████▍   | 120/188 [00:10<00:01, 35.23it/s]\u001b[A\n",
-      " 66%|██████▌   | 124/188 [00:10<00:01, 35.20it/s]\u001b[A\n",
-      " 68%|██████▊   | 128/188 [00:10<00:01, 35.19it/s]\u001b[A\n",
-      " 70%|███████   | 132/188 [00:10<00:01, 35.24it/s]\u001b[A\n",
-      " 72%|███████▏  | 136/188 [00:10<00:01, 35.26it/s]\u001b[A\n",
-      " 74%|███████▍  | 140/188 [00:10<00:01, 35.23it/s]\u001b[A\n",
-      " 77%|███████▋  | 144/188 [00:10<00:01, 35.27it/s]\u001b[A\n",
-      " 79%|███████▊  | 148/188 [00:11<00:01, 35.33it/s]\u001b[A\n",
-      " 81%|████████  | 152/188 [00:11<00:01, 35.41it/s]\u001b[A\n",
-      " 83%|████████▎ | 156/188 [00:11<00:00, 35.30it/s]\u001b[A\n",
-      " 85%|████████▌ | 160/188 [00:11<00:00, 35.41it/s]\u001b[A\n",
-      " 87%|████████▋ | 164/188 [00:11<00:00, 35.40it/s]\u001b[A\n",
-      " 89%|████████▉ | 168/188 [00:11<00:00, 35.35it/s]\u001b[A\n",
-      " 91%|█████████▏| 172/188 [00:11<00:00, 35.21it/s]\u001b[A\n",
-      " 94%|█████████▎| 176/188 [00:11<00:00, 35.22it/s]\u001b[A\n",
-      " 96%|█████████▌| 180/188 [00:11<00:00, 35.26it/s]\u001b[A\n",
-      " 98%|█████████▊| 184/188 [00:12<00:00, 35.27it/s]\u001b[A\n",
-      "                                                  [A\n",
-      " 33%|███▎      | 438/1314 [02:17<03:12,  4.54it/s]\n",
-      "100%|██████████| 188/188 [00:12<00:00, 33.31it/s]\u001b[A\n",
-      "                                                 \u001b[A"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/188 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.37783360481262207, 'eval_accuracy': 0.8933333333333333, 'eval_runtime': 13.524, 'eval_samples_per_second': 13.901, 'eval_steps_per_second': 13.901, 'epoch': 1.0}\n"
+      "{'eval_loss': 0.6022735834121704, 'eval_accuracy': 0.8906666666666667, 'eval_runtime': 13.8122, 'eval_samples_per_second': 13.611, 'eval_steps_per_second': 13.611, 'epoch': 2.0}\n",
+      "{'loss': 0.1476, 'learning_rate': 4.779299847792998e-06, 'epoch': 2.28}\n",
+      "{'loss': 0.0777, 'learning_rate': 1.7351598173515982e-06, 'epoch': 2.74}\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 46%|████▌     | 601/1314 [03:13<02:57,  4.03it/s]  "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'loss': 0.3495, 'learning_rate': 1.08675799086758e-05, 'epoch': 1.37}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 61%|██████    | 801/1314 [04:02<01:48,  4.72it/s]"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/188 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.1889, 'learning_rate': 7.823439878234399e-06, 'epoch': 1.83}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 67%|██████▋   | 876/1314 [04:18<01:32,  4.72it/s]\n",
-      "  0%|          | 0/188 [00:00<?, ?it/s]\u001b[A\n",
-      "  1%|          | 2/188 [00:00<00:50,  3.67it/s]\u001b[A\n",
-      "  2%|▏         | 3/188 [00:01<01:05,  2.81it/s]\u001b[A\n",
-      "  2%|▏         | 4/188 [00:01<01:04,  2.87it/s]\u001b[A\n",
-      "  3%|▎         | 5/188 [00:01<01:05,  2.80it/s]\u001b[A\n",
-      "  3%|▎         | 6/188 [00:02<01:11,  2.55it/s]\u001b[A\n",
-      "  4%|▎         | 7/188 [00:02<01:07,  2.68it/s]\u001b[A\n",
-      "  4%|▍         | 8/188 [00:02<01:06,  2.73it/s]\u001b[A\n",
-      "  5%|▍         | 9/188 [00:03<01:08,  2.62it/s]\u001b[A\n",
-      "  5%|▌         | 10/188 [00:03<01:02,  2.84it/s]\u001b[A\n",
-      "  6%|▌         | 11/188 [00:04<01:03,  2.77it/s]\u001b[A\n",
-      "  6%|▋         | 12/188 [00:04<01:06,  2.64it/s]\u001b[A\n",
-      "  7%|▋         | 13/188 [00:04<01:05,  2.67it/s]\u001b[A\n",
-      "  7%|▋         | 14/188 [00:05<01:04,  2.71it/s]\u001b[A\n",
-      "  8%|▊         | 15/188 [00:05<01:04,  2.66it/s]\u001b[A\n",
-      "  9%|▊         | 16/188 [00:05<00:56,  3.07it/s]\u001b[A\n",
-      " 10%|▉         | 18/188 [00:05<00:36,  4.60it/s]\u001b[A\n",
-      " 11%|█         | 20/188 [00:06<00:26,  6.40it/s]\u001b[A\n",
-      " 12%|█▏        | 22/188 [00:06<00:20,  8.03it/s]\u001b[A\n",
-      " 13%|█▎        | 24/188 [00:06<00:16,  9.80it/s]\u001b[A\n",
-      " 14%|█▍        | 26/188 [00:06<00:14, 10.82it/s]\u001b[A\n",
-      " 15%|█▍        | 28/188 [00:06<00:13, 11.70it/s]\u001b[A\n",
-      " 16%|█▌        | 30/188 [00:06<00:12, 12.31it/s]\u001b[A\n",
-      " 17%|█▋        | 32/188 [00:06<00:11, 13.52it/s]\u001b[A\n",
-      " 18%|█▊        | 34/188 [00:06<00:11, 13.19it/s]\u001b[A\n",
-      " 19%|█▉        | 36/188 [00:07<00:11, 12.73it/s]\u001b[A\n",
-      " 20%|██        | 38/188 [00:07<00:11, 12.95it/s]\u001b[A\n",
-      " 21%|██▏       | 40/188 [00:07<00:10, 13.76it/s]\u001b[A\n",
-      " 22%|██▏       | 42/188 [00:07<00:11, 13.21it/s]\u001b[A\n",
-      " 23%|██▎       | 44/188 [00:07<00:10, 13.36it/s]\u001b[A\n",
-      " 24%|██▍       | 46/188 [00:07<00:10, 13.42it/s]\u001b[A\n",
-      " 26%|██▌       | 48/188 [00:08<00:10, 13.80it/s]\u001b[A\n",
-      " 27%|██▋       | 50/188 [00:08<00:09, 14.29it/s]\u001b[A\n",
-      " 28%|██▊       | 52/188 [00:08<00:09, 14.77it/s]\u001b[A\n",
-      " 29%|██▊       | 54/188 [00:08<00:08, 15.54it/s]\u001b[A\n",
-      " 30%|██▉       | 56/188 [00:08<00:08, 15.65it/s]\u001b[A\n",
-      " 31%|███       | 58/188 [00:08<00:08, 15.07it/s]\u001b[A\n",
-      " 32%|███▏      | 60/188 [00:08<00:08, 15.04it/s]\u001b[A\n",
-      " 33%|███▎      | 62/188 [00:08<00:08, 15.37it/s]\u001b[A\n",
-      " 34%|███▍      | 64/188 [00:09<00:07, 15.77it/s]\u001b[A\n",
-      " 35%|███▌      | 66/188 [00:09<00:08, 15.08it/s]\u001b[A\n",
-      " 36%|███▌      | 68/188 [00:09<00:08, 14.50it/s]\u001b[A\n",
-      " 38%|███▊      | 72/188 [00:09<00:05, 19.45it/s]\u001b[A\n",
-      " 40%|████      | 76/188 [00:09<00:04, 24.11it/s]\u001b[A\n",
-      " 43%|████▎     | 80/188 [00:09<00:03, 27.80it/s]\u001b[A\n",
-      " 45%|████▍     | 84/188 [00:09<00:03, 30.60it/s]\u001b[A\n",
-      " 47%|████▋     | 88/188 [00:09<00:03, 32.67it/s]\u001b[A\n",
-      " 49%|████▉     | 92/188 [00:09<00:02, 34.18it/s]\u001b[A\n",
-      " 51%|█████     | 96/188 [00:10<00:02, 35.32it/s]\u001b[A\n",
-      " 53%|█████▎    | 100/188 [00:10<00:02, 36.24it/s]\u001b[A\n",
-      " 55%|█████▌    | 104/188 [00:10<00:02, 36.84it/s]\u001b[A\n",
-      " 57%|█████▋    | 108/188 [00:10<00:02, 37.28it/s]\u001b[A\n",
-      " 60%|█████▉    | 112/188 [00:10<00:02, 37.67it/s]\u001b[A\n",
-      " 62%|██████▏   | 116/188 [00:10<00:01, 37.65it/s]\u001b[A\n",
-      " 64%|██████▍   | 120/188 [00:10<00:01, 37.79it/s]\u001b[A\n",
-      " 66%|██████▌   | 124/188 [00:10<00:01, 37.88it/s]\u001b[A\n",
-      " 68%|██████▊   | 128/188 [00:10<00:01, 37.93it/s]\u001b[A\n",
-      " 70%|███████   | 132/188 [00:11<00:01, 38.05it/s]\u001b[A\n",
-      " 72%|███████▏  | 136/188 [00:11<00:01, 38.17it/s]\u001b[A\n",
-      " 74%|███████▍  | 140/188 [00:11<00:01, 38.26it/s]\u001b[A\n",
-      " 77%|███████▋  | 144/188 [00:11<00:01, 38.35it/s]\u001b[A\n",
-      " 79%|███████▊  | 148/188 [00:11<00:01, 38.46it/s]\u001b[A\n",
-      " 81%|████████  | 152/188 [00:11<00:00, 38.51it/s]\u001b[A\n",
-      " 83%|████████▎ | 156/188 [00:11<00:00, 38.66it/s]\u001b[A\n",
-      " 85%|████████▌ | 160/188 [00:11<00:00, 38.74it/s]\u001b[A\n",
-      " 87%|████████▋ | 164/188 [00:11<00:00, 38.80it/s]\u001b[A\n",
-      " 89%|████████▉ | 168/188 [00:11<00:00, 38.82it/s]\u001b[A\n",
-      " 91%|█████████▏| 172/188 [00:12<00:00, 38.85it/s]\u001b[A\n",
-      " 94%|█████████▎| 176/188 [00:12<00:00, 38.86it/s]\u001b[A\n",
-      " 96%|█████████▌| 180/188 [00:12<00:00, 38.24it/s]\u001b[A\n",
-      " 98%|█████████▊| 184/188 [00:12<00:00, 38.53it/s]\u001b[A\n",
-      "                                                  [A\n",
-      " 67%|██████▋   | 876/1314 [04:31<01:32,  4.72it/s]\n",
-      "100%|██████████| 188/188 [00:12<00:00, 38.70it/s]\u001b[A\n",
-      "                                                 \u001b[A"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.5083866119384766, 'eval_accuracy': 0.908, 'eval_runtime': 13.1799, 'eval_samples_per_second': 14.264, 'eval_steps_per_second': 14.264, 'epoch': 2.0}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 76%|███████▌  | 1001/1314 [05:16<01:18,  3.98it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'loss': 0.1181, 'learning_rate': 4.779299847792998e-06, 'epoch': 2.28}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 91%|█████████▏| 1201/1314 [06:05<00:24,  4.69it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'loss': 0.0949, 'learning_rate': 1.7351598173515982e-06, 'epoch': 2.74}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1314/1314 [06:29<00:00,  4.80it/s]\n",
-      "  0%|          | 0/188 [00:00<?, ?it/s]\u001b[A\n",
-      "  1%|          | 2/188 [00:00<01:11,  2.59it/s]\u001b[A\n",
-      "  2%|▏         | 3/188 [00:01<01:35,  1.94it/s]\u001b[A\n",
-      "  2%|▏         | 4/188 [00:02<01:44,  1.77it/s]\u001b[A\n",
-      "  3%|▎         | 5/188 [00:02<01:45,  1.74it/s]\u001b[A\n",
-      "  3%|▎         | 6/188 [00:03<01:44,  1.74it/s]\u001b[A\n",
-      "  4%|▎         | 7/188 [00:03<01:44,  1.73it/s]\u001b[A\n",
-      "  4%|▍         | 8/188 [00:04<01:35,  1.89it/s]\u001b[A\n",
-      "  5%|▌         | 10/188 [00:04<00:55,  3.22it/s]\u001b[A\n",
-      "  6%|▋         | 12/188 [00:04<00:39,  4.47it/s]\u001b[A\n",
-      "  7%|▋         | 14/188 [00:04<00:29,  5.94it/s]\u001b[A\n",
-      "  9%|▊         | 16/188 [00:04<00:23,  7.36it/s]\u001b[A\n",
-      " 10%|▉         | 18/188 [00:05<00:19,  8.75it/s]\u001b[A\n",
-      " 11%|█         | 20/188 [00:05<00:16, 10.24it/s]\u001b[A\n",
-      " 12%|█▏        | 22/188 [00:05<00:14, 11.35it/s]\u001b[A\n",
-      " 13%|█▎        | 24/188 [00:05<00:12, 12.68it/s]\u001b[A\n",
-      " 14%|█▍        | 26/188 [00:05<00:12, 13.13it/s]\u001b[A\n",
-      " 15%|█▍        | 28/188 [00:05<00:11, 13.54it/s]\u001b[A\n",
-      " 16%|█▌        | 30/188 [00:05<00:11, 13.86it/s]\u001b[A\n",
-      " 17%|█▋        | 32/188 [00:05<00:10, 14.84it/s]\u001b[A\n",
-      " 18%|█▊        | 34/188 [00:06<00:10, 14.22it/s]\u001b[A\n",
-      " 19%|█▉        | 36/188 [00:06<00:11, 13.54it/s]\u001b[A\n",
-      " 20%|██        | 38/188 [00:06<00:10, 13.93it/s]\u001b[A\n",
-      " 21%|██▏       | 40/188 [00:06<00:10, 14.78it/s]\u001b[A\n",
-      " 22%|██▏       | 42/188 [00:06<00:10, 14.14it/s]\u001b[A\n",
-      " 23%|██▎       | 44/188 [00:06<00:10, 14.28it/s]\u001b[A\n",
-      " 24%|██▍       | 46/188 [00:06<00:09, 14.21it/s]\u001b[A\n",
-      " 26%|██▌       | 48/188 [00:07<00:09, 14.64it/s]\u001b[A\n",
-      " 27%|██▋       | 50/188 [00:07<00:09, 15.09it/s]\u001b[A\n",
-      " 28%|██▊       | 52/188 [00:07<00:08, 15.50it/s]\u001b[A\n",
-      " 29%|██▊       | 54/188 [00:07<00:08, 16.31it/s]\u001b[A\n",
-      " 30%|██▉       | 56/188 [00:07<00:08, 16.37it/s]\u001b[A\n",
-      " 31%|███       | 58/188 [00:07<00:08, 15.67it/s]\u001b[A\n",
-      " 32%|███▏      | 60/188 [00:07<00:08, 15.58it/s]\u001b[A\n",
-      " 33%|███▎      | 62/188 [00:07<00:07, 15.89it/s]\u001b[A\n",
-      " 34%|███▍      | 64/188 [00:08<00:07, 16.34it/s]\u001b[A\n",
-      " 35%|███▌      | 66/188 [00:08<00:07, 15.54it/s]\u001b[A\n",
-      " 36%|███▌      | 68/188 [00:08<00:08, 14.90it/s]\u001b[A\n",
-      " 38%|███▊      | 72/188 [00:08<00:05, 20.01it/s]\u001b[A\n",
-      " 40%|████      | 76/188 [00:08<00:04, 24.73it/s]\u001b[A\n",
-      " 43%|████▎     | 80/188 [00:08<00:03, 28.48it/s]\u001b[A\n",
-      " 45%|████▍     | 84/188 [00:08<00:03, 31.44it/s]\u001b[A\n",
-      " 47%|████▋     | 89/188 [00:08<00:02, 34.34it/s]\u001b[A\n",
-      " 50%|█████     | 94/188 [00:09<00:02, 36.23it/s]\u001b[A\n",
-      " 52%|█████▏    | 98/188 [00:09<00:02, 37.19it/s]\u001b[A\n",
-      " 55%|█████▍    | 103/188 [00:09<00:02, 38.17it/s]\u001b[A\n",
-      " 57%|█████▋    | 108/188 [00:09<00:02, 38.88it/s]\u001b[A\n",
-      " 60%|█████▉    | 112/188 [00:09<00:01, 38.93it/s]\u001b[A\n",
-      " 62%|██████▏   | 117/188 [00:09<00:01, 39.36it/s]\u001b[A\n",
-      " 65%|██████▍   | 122/188 [00:09<00:01, 39.64it/s]\u001b[A\n",
-      " 68%|██████▊   | 127/188 [00:09<00:01, 39.81it/s]\u001b[A\n",
-      " 70%|██████▉   | 131/188 [00:09<00:01, 39.86it/s]\u001b[A\n",
-      " 72%|███████▏  | 135/188 [00:10<00:01, 39.87it/s]\u001b[A\n",
-      " 74%|███████▍  | 139/188 [00:10<00:01, 39.86it/s]\u001b[A\n",
-      " 76%|███████▌  | 143/188 [00:10<00:01, 39.77it/s]\u001b[A\n",
-      " 78%|███████▊  | 147/188 [00:10<00:01, 39.57it/s]\u001b[A\n",
-      " 80%|████████  | 151/188 [00:10<00:00, 39.55it/s]\u001b[A\n",
-      " 82%|████████▏ | 155/188 [00:10<00:00, 39.57it/s]\u001b[A\n",
-      " 85%|████████▍ | 159/188 [00:10<00:00, 39.56it/s]\u001b[A\n",
-      " 87%|████████▋ | 163/188 [00:10<00:00, 38.84it/s]\u001b[A\n",
-      " 89%|████████▉ | 167/188 [00:10<00:00, 38.67it/s]\u001b[A\n",
-      " 91%|█████████ | 171/188 [00:10<00:00, 38.52it/s]\u001b[A\n",
-      " 93%|█████████▎| 175/188 [00:11<00:00, 38.42it/s]\u001b[A\n",
-      " 95%|█████████▌| 179/188 [00:11<00:00, 38.36it/s]\u001b[A\n",
-      " 97%|█████████▋| 183/188 [00:11<00:00, 38.32it/s]\u001b[A\n",
-      "                                                   A\n",
-      "100%|██████████| 1314/1314 [06:41<00:00,  4.80it/s]\n",
-      "100%|██████████| 188/188 [00:11<00:00, 38.32it/s]\u001b[A\n",
-      "                                                 \u001b[A"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.5479908585548401, 'eval_accuracy': 0.9106666666666666, 'eval_runtime': 12.6013, 'eval_samples_per_second': 14.919, 'eval_steps_per_second': 14.919, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1314/1314 [06:51<00:00,  3.19it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'train_runtime': 411.6353, 'train_samples_per_second': 12.769, 'train_steps_per_second': 3.192, 'train_loss': 0.280830503780185, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "{'eval_loss': 0.572710394859314, 'eval_accuracy': 0.9026666666666666, 'eval_runtime': 13.7343, 'eval_samples_per_second': 13.688, 'eval_steps_per_second': 13.688, 'epoch': 3.0}\n",
+      "{'train_runtime': 585.155, 'train_samples_per_second': 8.982, 'train_steps_per_second': 2.246, 'train_loss': 0.27094667650974685, 'epoch': 3.0}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TrainOutput(global_step=1314, training_loss=0.280830503780185, metrics={'train_runtime': 411.6353, 'train_samples_per_second': 12.769, 'train_steps_per_second': 3.192, 'train_loss': 0.280830503780185, 'epoch': 3.0})"
+       "TrainOutput(global_step=1314, training_loss=0.27094667650974685, metrics={'train_runtime': 585.155, 'train_samples_per_second': 8.982, 'train_steps_per_second': 2.246, 'train_loss': 0.27094667650974685, 'epoch': 3.0})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -784,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "tags": []
    },
@@ -820,21 +625,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/188 [00:14<?, ?it/s]"
+      "  0%|          | 0/188 [00:15<?, ?it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.9095744680851063\n"
+      "Accuracy: 0.901595744680851\n"
      ]
     },
     {
@@ -849,13 +654,6 @@
     "acc = evaluate_fn(model, dataset_val)\n",
     "print(f\"Accuracy: {acc}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -885,9 +683,9 @@
    "name": "mindspore1.7.0-cuda10.1-py3.7-ubuntu18.04"
   },
   "kernelspec": {
-   "display_name": "MindSpore",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "mindspore"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -899,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.21"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
任务
任务编号：#IC6YZS
任务链接：[【开源实习】技术公开课内容测试任务3](https://gitee.com/mindspore/community/issues/IC6YZS)
实现内容：实现了在mindspore2.5.0和mindnlp0.4.0套件上跑通反馈，并在pip install mindnlp和pip install mindspore处锁定版本如图：
![Mindspore2.5.0+Mindnlp0.4.0](https://github.com/user-attachments/assets/9250a199-c9fe-45e8-997b-b7c08951e77c)

**训练正常：**
![train](https://github.com/user-attachments/assets/5cec6ba6-a837-4bc3-85ba-0790a7718a2d)

**原版：**
![origin](https://github.com/user-attachments/assets/1283a2b9-56ed-4307-be5f-adb989f42a73)
**测试任务模型：**
![new](https://github.com/user-attachments/assets/6e825150-a91d-4395-bc07-4bd721b9fda0)


 **测试模型** 和 **原版模型** 的性能对比表格：
指标 | 测试任务模型 | 原版模型 | 对比分析
-- | -- | -- | --
Acc | ``0.901595744680851`` | ``0.9095744680851063`` | 几乎相同（相差约 0.87%）
