### PR TITLE
【开源实习】技术公开课内容测试任务4

### DIFF
--- a/Season1.step_into_chatgpt/4.GPT2/gpt2_modules.ipynb
+++ b/Season1.step_into_chatgpt/4.GPT2/gpt2_modules.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "e60ce5a7-b42a-4669-affa-99fb526e3c35",
    "metadata": {},
    "outputs": [],
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6e6f72a8-30cd-44ec-a884-4be46b6059bd",
    "metadata": {},
    "outputs": [],
@@ -100,15 +100,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "52f84d8f-746d-4a87-af68-2dadf693f002",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%capture captured_output\n",
-    "!pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.2.14/MindSpore/unified/x86_64/mindspore-2.2.14-cp39-cp39-linux_x86_64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple\n",
+    "#修改为在线 并锁定版本\n",
+    "!pip install mindspore==2.2.14 -i https://mirrors.aliyun.com/pypi/simple \n",
+    "#!pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.2.14/MindSpore/unified/x86_64/mindspore-2.2.14-cp39-cp39-linux_x86_64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple\n",
     "!pip install tokenizers==0.15.0 -i https://pypi.tuna.tsinghua.edu.cn/simple\n",
+    "\n",
     "!wget https://repo.mindspore.cn/mindspore-lab/mindnlp/daily/202402/20240229/master_20240229160016_c5444092d8cfe47d73e292f25d9a9a56fb04828a_newest/any/mindnlp-0.2.0.20240229-py3-none-any.whl\n",
+    "\n",
     "!pip install mindnlp"
    ]
   },
@@ -122,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "074df3ae-4bfc-4655-be9f-8041fc211f96",
    "metadata": {
     "tags": []
@@ -134,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "9a161bfb-a15e-4a07-9bb0-688b76f87de3",
    "metadata": {
     "tags": []
@@ -164,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "76d2591f-26c2-4961-bca3-be30c4352aef",
    "metadata": {
     "tags": []
@@ -181,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "2d315a4e-5663-404e-b93d-efb1cf354414",
    "metadata": {
     "tags": []
@@ -191,9 +195,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/ma-user/anaconda3/envs/python-3.9.0/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
+      "/home/filament/.local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Building prefix dict from the default dictionary ...\n",
+      "Loading model from cache /tmp/jieba.cache\n",
+      "Loading model cost 0.308 seconds.\n",
+      "Prefix dict has been built successfully.\n"
      ]
     },
     {
@@ -202,7 +209,7 @@
        "((1, 10, 768), (1, 10, 768), (1, 10, 768))"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "abb7ccac-7cfe-401a-ab32-763de70b4669",
    "metadata": {
     "tags": []
@@ -250,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "72abe0fe-5225-425b-9bda-0723f3fb27cf",
    "metadata": {
     "tags": []
@@ -262,7 +269,7 @@
        "((1, 12, 10, 64), (1, 12, 10, 64), (1, 12, 10, 64))"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "9f952236-de74-4419-9469-7e78d3b7c3e4",
    "metadata": {
     "tags": []
@@ -305,7 +312,7 @@
        "(1, 12, 10, 10)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "0ff22248-deff-4962-afae-55772f63f142",
    "metadata": {
     "tags": []
@@ -350,7 +357,7 @@
        "   [ True,  True,  True ...  True,  True,  True]]]])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -377,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "d957ce17-6df6-4f5e-a262-24ff3a8ce0d1",
    "metadata": {
     "tags": []
@@ -395,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "dee63bfd-f394-4558-9e9f-e102a2fd283c",
    "metadata": {
     "tags": []
@@ -407,7 +414,7 @@
        "-3.4028235e+38"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "d2faad14-9a3d-4495-8bcc-d7ac2695e83d",
    "metadata": {},
    "outputs": [
@@ -426,16 +433,16 @@
      "data": {
       "text/plain": [
        "Tensor(shape=[10, 10], dtype=Float32, value=\n",
-       "[[-3.72267663e-01, -3.40282347e+38, -3.40282347e+38 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
-       " [ 4.12474960e-01, -6.20999515e-01, -3.40282347e+38 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
-       " [ 1.29110947e-01,  2.28423685e-01, -1.90024704e-01 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
+       "[[-2.52325647e-02, -3.40282347e+38, -3.40282347e+38 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
+       " [-2.40131348e-01, -3.01081717e-01, -3.40282347e+38 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
+       " [-1.63813263e-01,  3.72520477e-01,  8.26954842e-02 ... -3.40282347e+38, -3.40282347e+38, -3.40282347e+38],\n",
        " ...\n",
-       " [ 2.14589074e-01,  1.79385528e-01,  2.11229175e-01 ... -8.21841732e-02, -3.40282347e+38, -3.40282347e+38],\n",
-       " [-3.86964470e-01,  1.50564313e-03, -7.81135634e-02 ... -8.60612690e-02, -3.31553906e-01, -3.40282347e+38],\n",
-       " [ 1.89703301e-01, -7.32186437e-02, -2.44263425e-01 ...  4.69686151e-01, -6.34481907e-01,  6.83065802e-02]])"
+       " [-3.40138614e-01,  7.31956363e-01, -3.32098126e-01 ... -5.13645589e-01, -3.40282347e+38, -3.40282347e+38],\n",
+       " [ 2.78025586e-02, -2.18080640e-01, -2.97767907e-01 ... -1.27004489e-01,  1.84989065e-01, -3.40282347e+38],\n",
+       " [ 1.32980525e-01, -5.72599649e-01,  6.88928843e-01 ... -1.89585343e-01,  1.92393050e-01,  4.59578540e-03]])"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "df9cdaae-ac5a-4bc0-9e59-403d176c0d3b",
    "metadata": {
     "tags": []
@@ -466,7 +473,7 @@
        "(1, 12, 10, 10)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "5771f68c-8b35-4b1a-83d1-287b2ce7a47e",
    "metadata": {
     "tags": []
@@ -489,15 +496,15 @@
       "text/plain": [
        "Tensor(shape=[10, 10], dtype=Float32, value=\n",
        "[[ 1.00000000e+00,  0.00000000e+00,  0.00000000e+00 ...  0.00000000e+00,  0.00000000e+00,  0.00000000e+00],\n",
-       " [ 7.37588942e-01,  2.62411058e-01,  0.00000000e+00 ...  0.00000000e+00,  0.00000000e+00,  0.00000000e+00],\n",
-       " [ 3.53208542e-01,  3.90087605e-01,  2.56703824e-01 ...  0.00000000e+00,  0.00000000e+00,  0.00000000e+00],\n",
+       " [ 5.15232861e-01,  4.84767109e-01,  0.00000000e+00 ...  0.00000000e+00,  0.00000000e+00,  0.00000000e+00],\n",
+       " [ 2.50672013e-01,  4.28580821e-01,  3.20747197e-01 ...  0.00000000e+00,  0.00000000e+00,  0.00000000e+00],\n",
        " ...\n",
-       " [ 1.25348046e-01,  1.21012121e-01,  1.24927595e-01 ...  9.31602344e-02,  0.00000000e+00,  0.00000000e+00],\n",
-       " [ 8.72338116e-02,  1.28645703e-01,  1.18800178e-01 ...  1.17859736e-01,  9.22039151e-02,  0.00000000e+00],\n",
-       " [ 1.08949542e-01,  8.37606117e-02,  7.05920979e-02 ...  1.44151926e-01,  4.77844179e-02,  9.64947045e-02]])"
+       " [ 9.36088935e-02,  2.73478150e-01,  9.43645760e-02 ...  7.86981434e-02,  0.00000000e+00,  0.00000000e+00],\n",
+       " [ 9.77324694e-02,  7.64280781e-02,  7.05739334e-02 ...  8.37157145e-02,  1.14367887e-01,  0.00000000e+00],\n",
+       " [ 1.11171417e-01,  5.48988841e-02,  1.93837821e-01 ...  8.05201530e-02,  1.17976539e-01,  9.77769196e-02]])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "0ba1e0ff-5627-4b70-8911-4ffa7383e29d",
    "metadata": {
     "tags": []
@@ -528,7 +535,7 @@
        "(1, 12, 10, 64)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -551,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "80e44dd1-4013-4d01-b267-92463b296e5b",
    "metadata": {
     "tags": []
@@ -570,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "5b35f8ee-70b4-4cb4-ad9b-d0b685482b59",
    "metadata": {
     "tags": []
@@ -582,7 +589,7 @@
        "(1, 10, 768)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -606,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "ff788df6-a6a7-4b43-9a76-95eaef4918c7",
    "metadata": {
     "tags": []
@@ -618,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "0c7d4c1f-4ddc-4605-acba-f6e17cbfe2d5",
    "metadata": {
     "tags": []
@@ -630,7 +637,7 @@
        "(1, 10, 768)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -660,9 +667,9 @@
    "name": "mindspore1.7.0-cuda10.1-py3.7-ubuntu18.04"
   },
   "kernelspec": {
-   "display_name": "ms2.2.14",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "ms2.2.14"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -674,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/Season1.step_into_chatgpt/4.GPT2/gpt2_summarization.ipynb
+++ b/Season1.step_into_chatgpt/4.GPT2/gpt2_summarization.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f9f085c7-b2b3-4b18-95f9-13b298b10d58",
    "metadata": {},
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 2,
    "id": "6491560b-1ec6-4ca1-88cc-c7f9c1297725",
    "metadata": {},
    "outputs": [
@@ -83,109 +83,122 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Looking in indexes: http://pip.modelarts.private.com:8888/repository/pypi/simple\n",
-      "Processing ./mindnlp-0.4.1-py3-none-any.whl\n",
-      "Requirement already satisfied: addict in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (2.4.0)\n",
-      "Requirement already satisfied: pytest==7.2.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (7.2.0)\n",
-      "Requirement already satisfied: tqdm in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (4.66.4)\n",
-      "Requirement already satisfied: regex in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (2024.7.24)\n",
-      "Requirement already satisfied: evaluate in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.4.3)\n",
-      "Requirement already satisfied: pyctcdecode in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.5.0)\n",
-      "Requirement already satisfied: ml-dtypes in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.4.0)\n",
-      "Requirement already satisfied: sentencepiece in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.2.0)\n",
-      "Requirement already satisfied: tokenizers==0.19.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.19.1)\n",
-      "Requirement already satisfied: datasets in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (3.1.0)\n",
-      "Requirement already satisfied: safetensors in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (0.4.5)\n",
-      "Requirement already satisfied: pillow>=10.0.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (10.0.1)\n",
-      "Requirement already satisfied: mindspore>=2.2.14 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (2.4.0)\n",
-      "Requirement already satisfied: requests in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindnlp==0.4.1) (2.32.3)\n",
-      "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (1.2.2)\n",
-      "Requirement already satisfied: pluggy<2.0,>=0.12 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (1.5.0)\n",
-      "Requirement already satisfied: attrs>=19.2.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (23.2.0)\n",
-      "Requirement already satisfied: packaging in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (24.1)\n",
-      "Requirement already satisfied: iniconfig in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (2.0.0)\n",
-      "Requirement already satisfied: tomli>=1.0.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (2.0.1)\n",
-      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from tokenizers==0.19.1->mindnlp==0.4.1) (0.24.2)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (4.12.2)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (2024.6.1)\n",
-      "Requirement already satisfied: filelock in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (3.15.4)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (6.0.1)\n",
-      "Requirement already satisfied: psutil>=5.6.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (5.9.5)\n",
-      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.22.0)\n",
-      "Requirement already satisfied: astunparse>=1.6.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.6.3)\n",
-      "Requirement already satisfied: asttokens>=2.0.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (2.4.1)\n",
-      "Requirement already satisfied: scipy>=1.5.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.10.1)\n",
-      "Requirement already satisfied: protobuf>=3.13.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (3.20.2)\n",
-      "Requirement already satisfied: six>=1.12.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from asttokens>=2.0.4->mindspore>=2.2.14->mindnlp==0.4.1) (1.16.0)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.1) (0.38.4)\n",
-      "Requirement already satisfied: pandas in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (1.3.5)\n",
-      "Requirement already satisfied: multiprocess<0.70.17 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (0.70.16)\n",
-      "Requirement already satisfied: dill<0.3.9,>=0.3.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (0.3.8)\n",
-      "Requirement already satisfied: aiohttp in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (3.11.9)\n",
-      "Requirement already satisfied: pyarrow>=15.0.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (18.1.0)\n",
-      "Requirement already satisfied: xxhash in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from datasets->mindnlp==0.4.1) (3.5.0)\n",
-      "Requirement already satisfied: async-timeout<6.0,>=4.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (5.0.1)\n",
-      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (2.4.4)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (6.1.0)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (1.3.1)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (1.18.3)\n",
-      "Requirement already satisfied: propcache>=0.2.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (0.2.1)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from aiohttp->datasets->mindnlp==0.4.1) (1.5.0)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->mindnlp==0.4.1) (2.0.12)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->mindnlp==0.4.1) (2024.7.4)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->mindnlp==0.4.1) (1.26.7)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->mindnlp==0.4.1) (2.10)\n",
-      "Requirement already satisfied: pytz>=2017.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.1) (2024.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.7.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pandas->datasets->mindnlp==0.4.1) (2.9.0.post0)\n",
-      "Requirement already satisfied: hypothesis<7,>=6.14 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.1) (6.122.1)\n",
-      "Requirement already satisfied: pygtrie<3.0,>=2.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from pyctcdecode->mindnlp==0.4.1) (2.5.0)\n",
-      "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from hypothesis<7,>=6.14->pyctcdecode->mindnlp==0.4.1) (2.4.0)\n",
-      "mindnlp is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.\n",
-      "\u001b[33mWARNING: You are using pip version 21.0.1; however, version 24.3.1 is available.\n",
-      "You should consider upgrading via the '/home/ma-user/anaconda3/envs/MindSpore/bin/python3.9 -m pip install --upgrade pip' command.\u001b[0m\n",
+      "Defaulting to user installation because normal site-packages is not writeable\n",
       "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\n",
-      "Requirement already satisfied: tokenizers==0.19.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (0.19.1)\n",
-      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from tokenizers==0.19.1) (0.24.2)\n",
-      "Requirement already satisfied: packaging>=20.9 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (24.1)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2024.6.1)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (6.0.1)\n",
-      "Requirement already satisfied: tqdm>=4.42.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (4.66.4)\n",
-      "Requirement already satisfied: requests in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2.32.3)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (4.12.2)\n",
-      "Requirement already satisfied: filelock in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (3.15.4)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2.0.12)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2.10)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2024.7.4)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (1.26.7)\n",
-      "\u001b[33mWARNING: You are using pip version 21.0.1; however, version 24.3.1 is available.\n",
-      "You should consider upgrading via the '/home/ma-user/anaconda3/envs/MindSpore/bin/python3.9 -m pip install --upgrade pip' command.\u001b[0m\n",
+      "Requirement already satisfied: mindnlp==0.4.1 in /home/filament/.local/lib/python3.10/site-packages (0.4.1)\n",
+      "Requirement already satisfied: mindspore>=2.2.14 in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (2.4.0)\n",
+      "Requirement already satisfied: tqdm in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (4.67.1)\n",
+      "Requirement already satisfied: requests in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (2.32.3)\n",
+      "Requirement already satisfied: datasets in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (3.6.0)\n",
+      "Requirement already satisfied: evaluate in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.4.3)\n",
+      "Requirement already satisfied: tokenizers==0.19.1 in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.19.1)\n",
+      "Requirement already satisfied: safetensors in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.5.3)\n",
+      "Requirement already satisfied: sentencepiece in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.2.0)\n",
+      "Requirement already satisfied: regex in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (2024.11.6)\n",
+      "Requirement already satisfied: addict in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (2.4.0)\n",
+      "Requirement already satisfied: ml-dtypes in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.5.1)\n",
+      "Requirement already satisfied: pyctcdecode in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (0.5.0)\n",
+      "Requirement already satisfied: pytest==7.2.0 in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (7.2.0)\n",
+      "Requirement already satisfied: pillow>=10.0.0 in /home/filament/.local/lib/python3.10/site-packages (from mindnlp==0.4.1) (11.1.0)\n",
+      "Requirement already satisfied: attrs>=19.2.0 in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (25.3.0)\n",
+      "Requirement already satisfied: iniconfig in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (2.1.0)\n",
+      "Requirement already satisfied: packaging in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (24.2)\n",
+      "Requirement already satisfied: pluggy<2.0,>=0.12 in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (1.5.0)\n",
+      "Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (1.2.2)\n",
+      "Requirement already satisfied: tomli>=1.0.0 in /home/filament/.local/lib/python3.10/site-packages (from pytest==7.2.0->mindnlp==0.4.1) (2.2.1)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/filament/.local/lib/python3.10/site-packages (from tokenizers==0.19.1->mindnlp==0.4.1) (0.32.0)\n",
+      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.26.4)\n",
+      "Requirement already satisfied: protobuf>=3.13.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (6.30.2)\n",
+      "Requirement already satisfied: asttokens>=2.0.4 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (3.0.0)\n",
+      "Requirement already satisfied: scipy>=1.5.4 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.15.2)\n",
+      "Requirement already satisfied: psutil>=5.6.1 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (7.0.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.3 in /home/filament/.local/lib/python3.10/site-packages (from mindspore>=2.2.14->mindnlp==0.4.1) (1.6.3)\n",
+      "Requirement already satisfied: filelock in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (3.18.0)\n",
+      "Requirement already satisfied: pyarrow>=15.0.0 in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (20.0.0)\n",
+      "Requirement already satisfied: dill<0.3.9,>=0.3.0 in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (0.3.8)\n",
+      "Requirement already satisfied: pandas in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (2.2.3)\n",
+      "Requirement already satisfied: xxhash in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (3.5.0)\n",
+      "Requirement already satisfied: multiprocess<0.70.17 in /home/filament/.local/lib/python3.10/site-packages (from datasets->mindnlp==0.4.1) (0.70.16)\n",
+      "Requirement already satisfied: fsspec<=2025.3.0,>=2023.1.0 in /home/filament/.local/lib/python3.10/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (2025.3.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /usr/lib/python3/dist-packages (from datasets->mindnlp==0.4.1) (6.0.1)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/filament/.local/lib/python3.10/site-packages (from requests->mindnlp==0.4.1) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests->mindnlp==0.4.1) (3.3)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3/dist-packages (from requests->mindnlp==0.4.1) (1.26.5)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests->mindnlp==0.4.1) (2020.6.20)\n",
+      "Requirement already satisfied: pygtrie<3.0,>=2.1 in /home/filament/.local/lib/python3.10/site-packages (from pyctcdecode->mindnlp==0.4.1) (2.5.0)\n",
+      "Requirement already satisfied: hypothesis<7,>=6.14 in /home/filament/.local/lib/python3.10/site-packages (from pyctcdecode->mindnlp==0.4.1) (6.131.25)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /usr/lib/python3/dist-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.1) (0.42.0)\n",
+      "Requirement already satisfied: six<2.0,>=1.6.1 in /usr/lib/python3/dist-packages (from astunparse>=1.6.3->mindspore>=2.2.14->mindnlp==0.4.1) (1.16.0)\n",
+      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/filament/.local/lib/python3.10/site-packages (from fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (3.11.18)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (4.13.2)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.2 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1->mindnlp==0.4.1) (1.1.2)\n",
+      "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /home/filament/.local/lib/python3.10/site-packages (from hypothesis<7,>=6.14->pyctcdecode->mindnlp==0.4.1) (2.4.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /home/filament/.local/lib/python3.10/site-packages (from pandas->datasets->mindnlp==0.4.1) (2.9.0.post0)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /usr/lib/python3/dist-packages (from pandas->datasets->mindnlp==0.4.1) (2022.1)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /home/filament/.local/lib/python3.10/site-packages (from pandas->datasets->mindnlp==0.4.1) (2025.2)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (1.3.2)\n",
+      "Requirement already satisfied: async-timeout<6.0,>=4.0 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (5.0.1)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (1.6.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (6.4.4)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (0.3.1)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/filament/.local/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.3.0,>=2023.1.0->datasets->mindnlp==0.4.1) (1.20.0)\n",
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\n",
+      "Requirement already satisfied: tokenizers==0.19.1 in /home/filament/.local/lib/python3.10/site-packages (0.19.1)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.16.4 in /home/filament/.local/lib/python3.10/site-packages (from tokenizers==0.19.1) (0.32.0)\n",
+      "Requirement already satisfied: filelock in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (3.18.0)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2025.3.0)\n",
+      "Requirement already satisfied: packaging>=20.9 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (24.2)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /usr/lib/python3/dist-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (6.0.1)\n",
+      "Requirement already satisfied: requests in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2.32.3)\n",
+      "Requirement already satisfied: tqdm>=4.42.1 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (4.67.1)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (4.13.2)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.2 in /home/filament/.local/lib/python3.10/site-packages (from huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (1.1.2)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/filament/.local/lib/python3.10/site-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (3.3)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3/dist-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (1.26.5)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests->huggingface-hub<1.0,>=0.16.4->tokenizers==0.19.1) (2020.6.20)\n",
       "env: no_proxy='a.test.com,127.0.0.1,2.2.2.2'\n",
-      "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple\n",
-      "Collecting mindspore==2.4.0\n",
-      "  Using cached https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.0/MindSpore/unified/aarch64/mindspore-2.4.0-cp39-cp39-linux_aarch64.whl (333.7 MB)\n",
-      "Requirement already satisfied: protobuf>=3.13.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (3.20.2)\n",
-      "Requirement already satisfied: psutil>=5.6.1 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (5.9.5)\n",
-      "Requirement already satisfied: asttokens>=2.0.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (2.4.1)\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (24.1)\n",
-      "Requirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (1.22.0)\n",
-      "Requirement already satisfied: safetensors>=0.4.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (0.4.5)\n",
-      "Requirement already satisfied: scipy>=1.5.4 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (1.10.1)\n",
-      "Requirement already satisfied: pillow>=6.2.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (10.0.1)\n",
-      "Requirement already satisfied: astunparse>=1.6.3 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from mindspore==2.4.0) (1.6.3)\n",
-      "Requirement already satisfied: six>=1.12.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from asttokens>=2.0.4->mindspore==2.4.0) (1.16.0)\n",
-      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages (from astunparse>=1.6.3->mindspore==2.4.0) (0.38.4)\n",
-      "\u001b[33mWARNING: You are using pip version 21.0.1; however, version 24.3.1 is available.\n",
-      "You should consider upgrading via the '/home/ma-user/anaconda3/envs/MindSpore/bin/python -m pip install --upgrade pip' command.\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n",
-      "\u001b[33mWARNING: Skipping mindformers as it is not installed.\u001b[0m\n"
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Looking in indexes: https://mirrors.aliyun.com/pypi/simple\n",
+      "Collecting mindspore==2.6.0rc1\n",
+      "  Downloading https://mirrors.aliyun.com/pypi/packages/d4/87/e1e9d36ac3397a9bf7aa45cc039adc63dd6c21dc7bb9b3ad9c343cc3e630/mindspore-2.6.0rc1-cp310-cp310-manylinux1_x86_64.whl (809.2 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m809.2/809.2 MB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:04\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: numpy<2.0.0,>=1.20.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (1.26.4)\n",
+      "Requirement already satisfied: protobuf>=3.13.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (6.30.2)\n",
+      "Requirement already satisfied: asttokens>=2.0.4 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (3.0.0)\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (11.1.0)\n",
+      "Requirement already satisfied: scipy>=1.5.4 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (1.15.2)\n",
+      "Requirement already satisfied: packaging>=20.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (24.2)\n",
+      "Requirement already satisfied: psutil>=5.6.1 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (7.0.0)\n",
+      "Requirement already satisfied: astunparse>=1.6.3 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (1.6.3)\n",
+      "Requirement already satisfied: safetensors>=0.4.0 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (0.5.3)\n",
+      "Requirement already satisfied: dill>=0.3.7 in /home/filament/.local/lib/python3.10/site-packages (from mindspore==2.6.0rc1) (0.3.8)\n",
+      "Requirement already satisfied: wheel<1.0,>=0.23.0 in /usr/lib/python3/dist-packages (from astunparse>=1.6.3->mindspore==2.6.0rc1) (0.42.0)\n",
+      "Requirement already satisfied: six<2.0,>=1.6.1 in /usr/lib/python3/dist-packages (from astunparse>=1.6.3->mindspore==2.6.0rc1) (1.16.0)\n",
+      "Installing collected packages: mindspore\n",
+      "  Attempting uninstall: mindspore\n",
+      "    Found existing installation: mindspore 2.4.0\n",
+      "    Uninstalling mindspore-2.4.0:\n",
+      "      Successfully uninstalled mindspore-2.4.0\n",
+      "Successfully installed mindspore-2.6.0rc1\n",
+      "\u001b[33mWARNING: Skipping mindformers as it is not installed.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
    "source": [
-    "!pip install mindnlp-0.4.1-py3-none-any.whl  # 将安装mindnlp版本更换为mindnlp-0.4.0-py3-none-any.whl（daily版本）\n",
+    "!pip install mindnlp==0.4.1 -i https://pypi.tuna.tsinghua.edu.cn/simple #改为在线并锁定版本\n",
+    "\n",
+    "#!pip install mindnlp-0.4.1-py3-none-any.whl  # 将安装mindnlp版本更换为mindnlp-0.4.0-py3-none-any.whl（daily版本）\n",
     "!pip install tokenizers==0.19.1 -i https://pypi.tuna.tsinghua.edu.cn/simple  # 修改tokenizers版本为0.19.1\n",
+    "\n",
     "%env no_proxy='a.test.com,127.0.0.1,2.2.2.2'\n",
-    "%pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.0/MindSpore/unified/aarch64/mindspore-2.4.0-cp39-cp39-linux_aarch64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple\n",
+    "\n",
+    "!pip install mindspore==2.6.0rc1 -i https://mirrors.aliyun.com/pypi/simple \n",
+    "\n",
+    "#%pip install https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.4.0/MindSpore/unified/aarch64/mindspore-2.4.0-cp39-cp39-linux_aarch64.whl --trusted-host ms-release.obs.cn-north-4.myhuaweicloud.com -i https://pypi.tuna.tsinghua.edu.cn/simple\n",
     "!pip uninstall mindformers -y"
    ]
   },
@@ -219,27 +232,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.821.904 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleGetModelId failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleGetModelId\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.821.956 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleLoadFromMem failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleLoadFromMem\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.821.975 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclmdlBundleUnload failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclmdlBundleUnload\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.822.162 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtGetMemUceInfo failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtGetMemUceInfo\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.822.179 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtDeviceTaskAbort failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtDeviceTaskAbort\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.822.193 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol aclrtMemUceRepair failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libascendcl.so: undefined symbol: aclrtMemUceRepair\n",
-      "[WARNING] GE_ADPT(12319,ffffaba360b0,python):2024-12-03-21:03:05.823.653 [mindspore/ccsrc/utils/dlopen_macro.h:163] DlsymAscend] Dynamically load symbol acltdtCleanChannel failed, result = /usr/local/Ascend/ascend-toolkit/latest/lib64/libacl_tdt_channel.so: undefined symbol: acltdtCleanChannel\n",
-      "[WARNING] ME(12319:281473561354416,MainProcess):2024-12-03-21:03:05.955.541 [mindspore/run_check/_check_version.py:396] Can not find the tbe operator implementation(need by mindspore-ascend). Please check whether the Environment Variable PYTHONPATH is set. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
-      "  return self._float_to_str(self.smallest_subnormal)\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
-      "  return self._float_to_str(self.smallest_subnormal)\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/home/filament/.local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n",
       "Building prefix dict from the default dictionary ...\n",
-      "Loading model from cache /tmp/jieba.cache\n",
-      "Loading model cost 1.298 seconds.\n",
+      "Dumping model to file cache /tmp/jieba.cache\n",
+      "Loading model cost 0.495 seconds.\n",
       "Prefix dict has been built successfully.\n"
      ]
     }
@@ -273,7 +270,7 @@
     "from mindspore.dataset import TextFileDataset\n",
     "\n",
     "# load dataset\n",
-    "dataset = TextFileDataset(str(path), shuffle=False)\n",
+    "dataset = TextFileDataset(str(path), shuffle=False) \n",
     "dataset.get_dataset_size()"
    ]
   },
@@ -370,7 +367,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/mindnlp/transformers/tokenization_utils_base.py:1526: FutureWarning: `clean_up_tokenization_spaces` was not set. It will be set to `True` by default. This behavior will be depracted, and will be then set to `False` by default. \n",
+      "/home/filament/.local/lib/python3.10/site-packages/mindnlp/transformers/tokenization_utils_base.py:1526: FutureWarning: `clean_up_tokenization_spaces` was not set. It will be set to `True` by default. This behavior will be depracted, and will be then set to `False` by default. \n",
       "  warnings.warn(\n"
      ]
     },
@@ -551,8 +548,14 @@
      "text": [
       "GPT2LMHeadModel has generative capabilities, as `prepare_inputs_for_generation` is explicitly overwritten. However, it doesn't directly inherit from `GenerationMixin`.`PreTrainedModel` will NOT inherit from `GenerationMixin`, and this model will lose the ability to call `generate` and other related functions.\n",
       "  - If you are the owner of the model architecture code, please modify your model class such that it inherits from `GenerationMixin` (after `PreTrainedModel`, otherwise you'll get an exception).\n",
-      "  - If you are not the owner of the model architecture class, please contact the model code owner to update it.\n",
-      "[WARNING] DEVICE(12319,ffffaba360b0,python):2024-12-03-21:03:34.197.849 [mindspore/ccsrc/plugin/device/ascend/hal/device/ascend_vmm_adapter.h:188] CheckVmmDriverVersion] Driver version is less than 24.0.0, vmm is disabled by default, drvier_version: 23.0.6\n"
+      "  - If you are not the owner of the model architecture class, please contact the model code owner to update it.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[MS_ALLOC_CONF]Runtime config:  enable_vmm:True  vmm_align_size:2MB\n"
      ]
     }
    ],
@@ -646,41 +649,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/45 [00:00<?, ?it/s]"
+      " 67%|██████▋   | 30/45 [05:39<02:33, 10.21s/it][WARNING] MD(777,7edbc9ffa6c0,python):2025-06-06-11:01:16.055.909 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 86.612%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "100%|██████████| 45/45 [08:48<00:00, 11.75s/it]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-\r"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 45/45 [00:32<00:00,  1.38it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'train_runtime': 32.5297, 'train_samples_per_second': 11.067, 'train_steps_per_second': 1.383, 'train_loss': 9.11246066623264, 'epoch': 1.0}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "{'train_runtime': 528.3991, 'train_samples_per_second': 0.681, 'train_steps_per_second': 0.085, 'train_loss': 9.115397135416666, 'epoch': 1.0}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TrainOutput(global_step=45, training_loss=9.11246066623264, metrics={'train_runtime': 32.5297, 'train_samples_per_second': 11.067, 'train_steps_per_second': 1.383, 'train_loss': 9.11246066623264, 'epoch': 1.0})"
+       "TrainOutput(global_step=45, training_loss=9.115397135416666, metrics={'train_runtime': 528.3991, 'train_samples_per_second': 0.681, 'train_steps_per_second': 0.085, 'train_loss': 9.115397135416666, 'epoch': 1.0})"
       ]
      },
      "execution_count": 15,
@@ -827,14 +810,39 @@
      "text": [
       "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
       "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n",
-      "The attention mask is not set and cannot be inferred from input because pad token is same as eos token. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n"
+      "The attention mask is not set and cannot be inferred from input because pad token is same as eos token. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:01.013.779 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 84.8249%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:01.644.571 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 86.232%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:02.259.817 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 87.3694%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:03.036.864 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.1888%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:04.017.105 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.1875%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:04.819.896 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2121%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:05.567.599 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2139%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:04.966.105 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2137%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:05.663.820 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2198%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:06.406.974 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2198%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:07.100.020 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2216%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:07.735.723 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2198%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:08.399.173 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2198%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:09.075.127 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2198%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:09.712.431 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2292%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:10.277.470 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2292%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:10.982.927 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2292%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:11.405.420 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2455%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:11.953.699 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2445%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:12.513.638 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2494%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:13.027.630 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2513%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:13.563.688 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.283%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:14.092.551 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2849%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:14.533.112 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2849%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(777,7edbcbffe6c0,python):2025-06-06-11:05:14.977.520 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:133] operator()] Memory consumption is more than 88.2849%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[CLS] 玉 林 新 闻 网 - 玉 林 晚 报 讯 （ 通 讯 员 < [UNK] > 黄 传 庆 ） 练 车 间 隙 ， 发 现 训 练 场 附 近 一 根 电 线 杆 上 有 一 个 鸟 窝 ， 21 岁 的 刁 某 立 即 爬 上 去 捉 鸟 ， 不 想 就 此 命 丧 黄 泉 。 日 前 发 生 在 博 白 县 文 地 镇 一 驾 校 训 练 场 的 意 外 事 故 ， 令 人 唏 嘘 。 今 年 21 岁 的 刁 某 是 博 白 县 宁 潭 镇 新 荣 村 人 ， 不 久 前 到 其 堂 叔 刁 某 某 任 教 练 的 宁 潭 镇 某 驾 校 参 加 汽 车 驾 驶 员 培 训 。 25 日 中 午 ， 刁 某 随 堂 叔 刁 某 某 及 另 外 几 名 学 员 开 车 到 文 地 镇 ， 借 用 文 地 镇 钛 白 粉 厂 附 近 的 训 练 场 练 车 。 14 时 许 ， 训 练 间 隙 ， 刁 某 发 现 训 练 场 附 近 一 根 电 线 杆 上 有 一 个 鸟 窝 ， 一 只 [UNK] 八 哥 [UNK] 正 叼 着 虫 子 飞 回 鸟 窝 。 平 时 刁 某 偶 尔 会 捕 鸟 出 卖 ， 知 道 这 种 鸟 价 值 100 多 元 。 他 跟 身 边 学 员 打 了 个 招 呼 ， 便 飞 奔 过 去 ， 欲 爬 上 电 线 杆 捉 鸟 。 刁 某 某 发 现 后 追 过 去 欲 阻 止 ， 但 为 时 已 晚 ， 等 刁 某 某 赶 到 时 ， 刁 某 已 爬 到 电 线 杆 顶 ， 伸 手 捉 鸟 时 不 慎 触 碰 到 头 顶 的 高 压 电 线 ， 当 即 身 亡 。 其 手 掌 被 外 露 的 钢 枝 刺 穿 ， 尸 体 悬 挂 在 电 线 杆 上 。 26 日 下 午 ， 在 文 地 、 宁 潭 镇 政 府 及 相 关 部 门 协 调 下 ， 相 关 责 任 方 与 死 者 家 属 达 成 赔 偿 协 议 ， 死 者 家 属 同 意 将 死 者 尸 体 取 下 搬 走 ， 相 关 责 任 方 共 赔 偿 死 者 家 属 15. 8 万 元 ， 其 中 宁 潭 镇 某 驾 校 赔 付 7. 3 万 元 ， 死 者 堂 叔 刁 某 某 （ 驾 校 教 练 ） 赔 付 5. 3 万 元 ， 文 地 供 电 所 本 来 没 有 直 接 责 任 ， 但 出 于 人 道 主 义 赔 付 3. 2 万 元 。 （ 原 标 题 ： 为 捉 一 只 鸟 < [UNK] > 赔 上 一 条 命 博 白 一 男 子 爬 电 线 杆 捉 鸟 ， 不 慎 触 电 身 亡 ） [SEP] ， 。 ， ， 的 ， [UNK] 的 的 。 。 [UNK] ， 了 ， 大 的 了 。 的 [UNK] 。 一 的 一 ， 出 ， 上 ， 人 的 大 ， 和 ， 子 ， 到 ， 市 ， 有 ， 行 ， 也 ， < ，\n"
+      "[CLS] 玉 林 新 闻 网 - 玉 林 晚 报 讯 （ 通 讯 员 < [UNK] > 黄 传 庆 ） 练 车 间 隙 ， 发 现 训 练 场 附 近 一 根 电 线 杆 上 有 一 个 鸟 窝 ， 21 岁 的 刁 某 立 即 爬 上 去 捉 鸟 ， 不 想 就 此 命 丧 黄 泉 。 日 前 发 生 在 博 白 县 文 地 镇 一 驾 校 训 练 场 的 意 外 事 故 ， 令 人 唏 嘘 。 今 年 21 岁 的 刁 某 是 博 白 县 宁 潭 镇 新 荣 村 人 ， 不 久 前 到 其 堂 叔 刁 某 某 任 教 练 的 宁 潭 镇 某 驾 校 参 加 汽 车 驾 驶 员 培 训 。 25 日 中 午 ， 刁 某 随 堂 叔 刁 某 某 及 另 外 几 名 学 员 开 车 到 文 地 镇 ， 借 用 文 地 镇 钛 白 粉 厂 附 近 的 训 练 场 练 车 。 14 时 许 ， 训 练 间 隙 ， 刁 某 发 现 训 练 场 附 近 一 根 电 线 杆 上 有 一 个 鸟 窝 ， 一 只 [UNK] 八 哥 [UNK] 正 叼 着 虫 子 飞 回 鸟 窝 。 平 时 刁 某 偶 尔 会 捕 鸟 出 卖 ， 知 道 这 种 鸟 价 值 100 多 元 。 他 跟 身 边 学 员 打 了 个 招 呼 ， 便 飞 奔 过 去 ， 欲 爬 上 电 线 杆 捉 鸟 。 刁 某 某 发 现 后 追 过 去 欲 阻 止 ， 但 为 时 已 晚 ， 等 刁 某 某 赶 到 时 ， 刁 某 已 爬 到 电 线 杆 顶 ， 伸 手 捉 鸟 时 不 慎 触 碰 到 头 顶 的 高 压 电 线 ， 当 即 身 亡 。 其 手 掌 被 外 露 的 钢 枝 刺 穿 ， 尸 体 悬 挂 在 电 线 杆 上 。 26 日 下 午 ， 在 文 地 、 宁 潭 镇 政 府 及 相 关 部 门 协 调 下 ， 相 关 责 任 方 与 死 者 家 属 达 成 赔 偿 协 议 ， 死 者 家 属 同 意 将 死 者 尸 体 取 下 搬 走 ， 相 关 责 任 方 共 赔 偿 死 者 家 属 15. 8 万 元 ， 其 中 宁 潭 镇 某 驾 校 赔 付 7. 3 万 元 ， 死 者 堂 叔 刁 某 某 （ 驾 校 教 练 ） 赔 付 5. 3 万 元 ， 文 地 供 电 所 本 来 没 有 直 接 责 任 ， 但 出 于 人 道 主 义 赔 付 3. 2 万 元 。 （ 原 标 题 ： 为 捉 一 只 鸟 < [UNK] > 赔 上 一 条 命 博 白 一 男 子 爬 电 线 杆 捉 鸟 ， 不 慎 触 电 身 亡 ） [SEP] ， ， 。 ， 的 ， [UNK] 的 的 。 [UNK] 。 。 的 [UNK] [UNK] ， 年 ， 、 ， 成 ， 小 ， 生 ， 是 的 一 的 不 ， 了 ， 说 ， 出 ， 市 ， 下 的 在 ， 行 ， 人 的 年\n"
      ]
     }
    ],
@@ -881,9 +889,9 @@
    "name": "mindspore1.7.0-cuda10.1-py3.7-ubuntu18.04"
   },
   "kernelspec": {
-   "display_name": "MindSpore",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "mindspore"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -895,7 +903,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
任务
任务编号：#IC6Z40
任务链接：[【开源实习】技术公开课内容测试任务4 ](https://gitee.com/mindspore/community/issues/IC6Z40#note_41495014)
实现内容：

在`gpt2_summarization.ipynb`和   ` gpt2_modules.ipynb` 实现了在mindspore2.6.0rc1和mindnlp0.4.0套件上跑通反馈，并在`pip install mindnlp`和`pip install mindspore`处锁定版本如图：

![summarization锁定](https://github.com/user-attachments/assets/2828c488-f093-49f0-b64e-480192fab511)


![modules锁定版本](https://github.com/user-attachments/assets/e9dd648e-91d8-4568-8b2d-cc067ef32b8a)

训练结果如下


![成果2](https://github.com/user-attachments/assets/355a5c79-c3ab-4281-aacd-6e801a706755)

![训练成果](https://github.com/user-attachments/assets/f2d598d0-2444-4d21-b0aa-ca46f31cec56)



以下是 **测试模型** 和 **原版模型** 的性能对比表格：

| 指标                       | 原版模型         | 测试任务          | 对比分析（误差 / 说明）                    |
| -------------------------- | ---------------- | ----------------- | ------------------------------------------ |
| `global_step`              | 45               | 45                | 0%（一致）                                 |
| `training_loss`            | 9.11246066623264 | 9.115397135416666 | +0.032%（微幅上升）                        |
| `train_runtime`(秒)        | 32.5297          | 528.3991          | +1524%（由于我的电脑内存不足引发）         |
| `train_samples_per_second` | 11.067           | 0.681             | -93.8%（性能大幅下降，与运行时间变化一致） |
| `train_steps_per_second`   | 1.383            | 0.085             | -93.9%（训练步长更新速度明显降低）         |
| `epoch`                    | 1.0              | 1.0               | 0%（一致）                                 |